### PR TITLE
Add MCP endpoint

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -31,3 +31,19 @@ python3 train.py
 ```sh
 python3 main.py
 ```
+
+### MCP Endpoint
+
+The server exposes `/mcp` for Model Control Protocol operations. Example:
+
+```sh
+curl -X POST http://localhost:8080/mcp -H "Content-Type: application/json" \
+    -d '{"action": "list_models"}'
+```
+
+Supported actions:
+
+- `list_models` – return available model names.
+- `switch_model` – set the active model using `{"model": "lightgbm"}` or `{"model": "random_forest"}`.
+- `current_model` – display the currently active model.
+- `metadata` – return both available models and current selection.

--- a/server/mcp.py
+++ b/server/mcp.py
@@ -1,0 +1,55 @@
+from typing import Optional, Dict, List
+from pydantic import BaseModel
+
+# Available models that can be controlled via MCP
+AVAILABLE_MODELS: Dict[str, str] = {
+    "lightgbm": "LightGBM",
+    "random_forest": "Tuned Random Forest",
+}
+
+# Holds the key of the currently selected model if overridden via MCP
+current_model_override: Optional[str] = None
+
+class MCPRequest(BaseModel):
+    action: str
+    parameters: Optional[Dict[str, str]] = None
+
+class MCPResponse(BaseModel):
+    status: str
+    data: Optional[Dict[str, str]] = None
+    error: Optional[str] = None
+
+def list_models() -> List[str]:
+    return list(AVAILABLE_MODELS.values())
+
+def switch_model(model_key: str) -> str:
+    global current_model_override
+    if model_key not in AVAILABLE_MODELS:
+        raise ValueError("Unknown model")
+    current_model_override = model_key
+    return AVAILABLE_MODELS[model_key]
+
+def get_current_model() -> Optional[str]:
+    if current_model_override:
+        return AVAILABLE_MODELS[current_model_override]
+    return None
+
+def get_metadata() -> Dict[str, Optional[str]]:
+    return {
+        "available_models": AVAILABLE_MODELS,
+        "current_model": get_current_model(),
+    }
+
+def handle_mcp_action(action: str, parameters: Optional[Dict[str, str]] = None) -> Dict[str, Optional[str]]:
+    if action == "list_models":
+        return {"models": list_models()}
+    if action == "switch_model":
+        if not parameters or "model" not in parameters:
+            raise ValueError("'model' parameter required")
+        model_name = switch_model(parameters["model"])
+        return {"current_model": model_name}
+    if action == "current_model":
+        return {"current_model": get_current_model()}
+    if action == "metadata":
+        return get_metadata()
+    raise ValueError("Unsupported MCP action")

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -11,3 +11,4 @@ python-dotenv
 lightgbm
 matplotlib
 faiss-cpu
+pytest

--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -1,0 +1,28 @@
+import pytest
+from fastapi.testclient import TestClient
+from server.main import app
+import server.mcp as mcp
+
+client = TestClient(app)
+
+
+def test_list_models():
+    response = client.post('/mcp', json={'action': 'list_models'})
+    assert response.status_code == 200
+    data = response.json()
+    assert data['status'] == 'ok'
+    assert isinstance(data['data']['models'], list)
+
+
+def test_switch_model_and_current():
+    response = client.post('/mcp', json={'action': 'switch_model', 'parameters': {'model': 'lightgbm'}})
+    assert response.status_code == 200
+    assert response.json()['status'] == 'ok'
+    response = client.post('/mcp', json={'action': 'current_model'})
+    assert response.json()['data']['current_model'] == 'LightGBM'
+
+
+def test_switch_model_invalid():
+    response = client.post('/mcp', json={'action': 'switch_model', 'parameters': {'model': 'unknown'}})
+    assert response.status_code == 200
+    assert response.json()['status'] == 'error'


### PR DESCRIPTION
## Summary
- support Model Control Protocol with new `/mcp` endpoint
- allow overriding the prediction model via MCP
- document how to use the MCP endpoint
- include pytest-based tests for the new feature

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6858d49025ec832489ef3012c59e8ef2