### PR TITLE
Extend MCP support

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -47,3 +47,6 @@ Supported actions:
 - `switch_model` – set the active model using `{"model": "lightgbm"}` or `{"model": "random_forest"}`.
 - `current_model` – display the currently active model.
 - `metadata` – return both available models and current selection.
+- `predict` – run the prediction logic with a patient payload (equivalent to the `/predict` endpoint).
+- `recommendations` – generate recommendations for a patient (equivalent to the `/recommendations` endpoint).
+- `chat` – invoke the chat agent using a `ChatRequest` payload.


### PR DESCRIPTION
## Summary
- support complex request types in `MCPRequest`
- expose server API methods (`predict`, `recommendations`, `chat`) through MCP
- document new MCP actions in the server README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685da274575883248d41f37981db5cde