### PR TITLE
Extend MCP support

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -47,3 +47,64 @@ Supported actions:
 - `switch_model` – set the active model using `{"model": "lightgbm"}` or `{"model": "random_forest"}`.
 - `current_model` – display the currently active model.
 - `metadata` – return both available models and current selection.
+- `predict` – run the prediction logic with a patient payload (equivalent to the `/predict` endpoint).
+- `recommendations` – generate recommendations for a patient (equivalent to the `/recommendations` endpoint).
+- `chat` – invoke the chat agent using a `ChatRequest` payload.
+
+### Example requests
+
+List models
+
+```sh
+curl -X POST http://localhost:8080/mcp \
+    -H "Content-Type: application/json" \
+    -d '{"action": "list_models"}'
+```
+
+Switch model
+
+```sh
+curl -X POST http://localhost:8080/mcp \
+    -H "Content-Type: application/json" \
+    -d '{"action": "switch_model", "parameters": {"model": "lightgbm"}}'
+```
+
+Current model
+
+```sh
+curl -X POST http://localhost:8080/mcp \
+    -H "Content-Type: application/json" \
+    -d '{"action": "current_model"}'
+```
+
+Metadata
+
+```sh
+curl -X POST http://localhost:8080/mcp \
+    -H "Content-Type: application/json" \
+    -d '{"action": "metadata"}'
+```
+
+Predict
+
+```sh
+curl -X POST http://localhost:8080/mcp \
+    -H "Content-Type: application/json" \
+    -d '{"action": "predict", "parameters": {"PatientName": "Alice", "Glucose": 90, "BloodPressure": 80, "BMI": 25.0, "Age": 30, "Gender": 1, "Ethnicity": 3}}'
+```
+
+Recommendations
+
+```sh
+curl -X POST http://localhost:8080/mcp \
+    -H "Content-Type: application/json" \
+    -d '{"action": "recommendations", "parameters": {"PatientName": "Alice", "Glucose": 90, "BloodPressure": 80, "BMI": 25.0, "Age": 30, "Gender": 1, "Ethnicity": 3}}'
+```
+
+Chat
+
+```sh
+curl -X POST http://localhost:8080/mcp \
+    -H "Content-Type: application/json" \
+    -d '{"action": "chat", "parameters": {"history": [{"role": "user", "content": "Hi"}], "user_input": "What does my risk mean?", "patient_data": {"PatientName": "Alice", "Glucose": 90, "BloodPressure": 80, "BMI": 25.0, "Age": 30, "Gender": 1, "Ethnicity": 3}, "recommendations": {"finalRecommendation": "See your doctor"}, "predicted_risk": "No Diabetes", "risk_probability": "0.2"}}'
+```


### PR DESCRIPTION
## Summary
- support complex request types in `MCPRequest`
- expose server API methods (`predict`, `recommendations`, `chat`) through MCP
- document new MCP actions and add example calls in the server README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685da274575883248d41f37981db5cde